### PR TITLE
fixed: unicode characters in urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,13 @@ const fetch = global.fetch || require("node-fetch");
 const REGEX = /\["(\bhttps?:\/\/[^"]+)",(\d+),(\d+)\],null/g;
 
 /**
+ * @param {string} content
+ * @returns {string}
+ */
+const unicodeToString = (content) =>
+  content.replace(/\\u[\dA-F]{4}/gi, (match) => String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16)))
+
+/**
  * 
  * Async version of g-i-s module
  * @async
@@ -27,7 +34,7 @@ module.exports = async function gis(searchTerm, options = {}) {
 
   while (result = REGEX.exec(content))
     results.push({
-      url: result[1],
+      url: unicodeToString(result[1]),
       height: +result[2],
       width: +result[3]
     });


### PR DESCRIPTION
search `cats` got unicode urls which need to be string.
[current_url](https://th-thumbnailer.cdn-si-edu.com/ii_ZQzqzZgBKT6z9DVNhfPhZe5g//u003d/fit-in/1600x0/filters:focal(1061x707:1062x708)/https://tf-cmsv2-smithsonianmag-media.s3.amazonaws.com/filer_public/55/95/55958815-3a8a-4032-ac7a-ff8c8ec8898a/gettyimages-1067956982.jpg) after using `unicodeToString` [string_url](https://th-thumbnailer.cdn-si-edu.com/ii_ZQzqzZgBKT6z9DVNhfPhZe5g=/fit-in/1600x0/filters:focal(1061x707:1062x708)/https://tf-cmsv2-smithsonianmag-media.s3.amazonaws.com/filer_public/55/95/55958815-3a8a-4032-ac7a-ff8c8ec8898a/gettyimages-1067956982.jpg)

Test and accept the pull.